### PR TITLE
feat(exit): add system register read and write exit reasons

### DIFF
--- a/src/exit.rs
+++ b/src/exit.rs
@@ -96,17 +96,29 @@ pub enum AxVCpuExitReason {
         data: u64,
     },
     SysRegRead {
-        /// The address of the system register read.
+        /// Register identifier,
+        ///
+        /// Under Aarch64
+        /// following the ESR_EL2.ISS format:
+        ///  - <op0><op2><op1><CRn>00000<CRm>0,
+        /// consistent with the numbering in the `aarch64_sysreg` crate.
+        ///
+        /// Under x86_64 and RISC-V, this field is the address.
         addr: usize,
-        /// The system register number.
+        /// General-purpose register (GPR) number.
         reg: usize,
     },
     SysRegWrite {
-        /// The address of the system register write.
+        /// Register identifier,
+        ///
+        /// Under Aarch64
+        /// following the ESR_EL2.ISS format:
+        ///  - <op0><op2><op1><CRn>00000<CRm>0,
+        /// consistent with the numbering in the `aarch64_sysreg` crate.
+        ///
+        /// Under x86_64 and RISC-V, this field is the address.
         addr: usize,
-        /// The system register number.
-        reg: usize,
-        /// The data to be written.
+        /// Data to be written.
         value: u64,
     },
     /// The instruction executed by the vcpu performs a I/O read operation.

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -95,6 +95,20 @@ pub enum AxVCpuExitReason {
         /// The data to be written.
         data: u64,
     },
+    SysRegRead {
+        /// The address of the system register read.
+        addr: usize,
+        /// The system register number.
+        reg: usize,
+    },
+    SysRegWrite {
+        /// The address of the system register write.
+        addr: usize,
+        /// The system register number.
+        reg: usize,
+        /// The data to be written.
+        value: u64,
+    },
     /// The instruction executed by the vcpu performs a I/O read operation.
     ///
     /// It's unnecessary to specify the destination register because it's always `al`, `ax`, or `eax` (as port-I/O exists only in x86).


### PR DESCRIPTION
- Add SysRegRead and SysRegWrite variants to the AxVCpuExitReason enum
- SysRegRead contains address and register number for system register reads
- SysRegWrite contains address, register number, and data for system register writes