### PR TITLE
refactor: `AccessWidth` is defined redundantly in both axvcpu and axa…

### DIFF
--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,5 +1,5 @@
-use axaddrspace::{GuestPhysAddr, MappingFlags};
 use axaddrspace::device::AccessWidth;
+use axaddrspace::{GuestPhysAddr, MappingFlags};
 
 #[allow(unused_imports)] // used in doc
 use super::AxArchVCpu;

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,4 +1,5 @@
-use axaddrspace::{GuestPhysAddr, MappingFlags, device::AccessWidth};
+use axaddrspace::{GuestPhysAddr, MappingFlags};
+use axaddrspace::device::AccessWidth;
 
 #[allow(unused_imports)] // used in doc
 use super::AxArchVCpu;

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,64 +1,7 @@
-use axaddrspace::{GuestPhysAddr, MappingFlags};
+use axaddrspace::{GuestPhysAddr, MappingFlags, device::AccessWidth};
 
 #[allow(unused_imports)] // used in doc
 use super::AxArchVCpu;
-
-/// The width of an access.
-///
-/// Note that the term "word" here refers to 16-bit data, as in the x86 architecture.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum AccessWidth {
-    /// 8-bit access.
-    Byte,
-    /// 16-bit access.
-    Word,
-    /// 32-bit access.
-    Dword,
-    /// 64-bit access.
-    Qword,
-}
-
-impl TryFrom<usize> for AccessWidth {
-    type Error = ();
-
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        match value {
-            1 => Ok(Self::Byte),
-            2 => Ok(Self::Word),
-            4 => Ok(Self::Dword),
-            8 => Ok(Self::Qword),
-            _ => Err(()),
-        }
-    }
-}
-
-impl From<AccessWidth> for usize {
-    fn from(width: AccessWidth) -> usize {
-        match width {
-            AccessWidth::Byte => 1,
-            AccessWidth::Word => 2,
-            AccessWidth::Dword => 4,
-            AccessWidth::Qword => 8,
-        }
-    }
-}
-
-impl AccessWidth {
-    /// Returns the size of the access in bytes.
-    pub fn size(&self) -> usize {
-        (*self).into()
-    }
-
-    /// Returns the range of bits that the access covers.
-    pub fn bits_range(&self) -> core::ops::Range<usize> {
-        match self {
-            AccessWidth::Byte => 0..8,
-            AccessWidth::Word => 0..16,
-            AccessWidth::Dword => 0..32,
-            AccessWidth::Qword => 0..64,
-        }
-    }
-}
 
 /// The port number of an I/O operation.
 type Port = u16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,4 @@ pub use percpu::*;
 pub use vcpu::*;
 
 // TODO: consider, should [`AccessWidth`] be moved to a new crate?
-pub use exit::{AccessWidth, AxVCpuExitReason};
+pub use exit::AxVCpuExitReason;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,4 @@ pub use hal::AxVCpuHal;
 pub use percpu::*;
 pub use vcpu::*;
 
-// TODO: consider, should [`AccessWidth`] be moved to a new crate?
 pub use exit::AxVCpuExitReason;


### PR DESCRIPTION
…ddrspace. Remove it from axvcpu.

Rely on the following PRs
[axvcpu](https://github.com/arceos-hypervisor/axvcpu/pull/26)
[arm_vcpu](https://github.com/arceos-hypervisor/arm_vcpu/pull/30)
[x86_vcpu](https://github.com/arceos-hypervisor/x86_vcpu/pull/17)
